### PR TITLE
Sanitize Windows paths and update CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node }}
           cache: npm
@@ -46,10 +46,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -69,10 +69,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ mcpServers:
     "houjin-bangou-api": {
       "command": "node",
       "args": [
-        "C:\\Users\\owner\\OneDrive\\Desktop\\my_project\\houjin-bangou-api-mcp\\dist\\server.js"
+        "C:\\Users\\YOUR_USERNAME\\path\\to\\houjin-bangou-api-mcp\\dist\\server.js"
       ],
       "env": {
         "HOUJIN_BANGOU_API_APPLICATION_ID": "YOUR_APPLICATION_ID"

--- a/test/docs-and-fixtures.test.ts
+++ b/test/docs-and-fixtures.test.ts
@@ -12,6 +12,7 @@ type ManualCompanyCheck = {
 
 const README_PATH = new URL("../README.md", import.meta.url);
 const PACKAGE_JSON_PATH = new URL("../package.json", import.meta.url);
+const CI_WORKFLOW_PATH = new URL("../.github/workflows/ci.yml", import.meta.url);
 const MANUAL_FIXTURE_PATH = new URL("../scripts/manual-company-check.json", import.meta.url);
 const NATIONAL_TAX_AGENCY_NAME = "\u56fd\u7a0e\u5e81";
 const NINTENDO_NAME = "\u4efb\u5929\u5802\u682a\u5f0f\u4f1a\u793e";
@@ -41,6 +42,8 @@ test("README documents first-time setup, verification, package imports, and read
   assert.ok(readme.includes("## Structured Response Fields"));
   assert.ok(readme.includes("## Pagination"));
   assert.ok(readme.includes("Windows installs work even when the repository path contains non-ASCII characters"));
+  assert.ok(readme.includes("C:\\\\Users\\\\YOUR_USERNAME\\\\path\\\\to\\\\houjin-bangou-api-mcp\\\\dist\\\\server.js"));
+  assert.ok(!readme.includes("C:\\\\Users\\\\owner\\\\OneDrive\\\\Desktop\\\\my_project\\\\houjin-bangou-api-mcp\\\\dist\\\\server.js"));
   assert.ok(!readme.includes('"lastUpdateDate": "2026-03-11"'));
 });
 
@@ -61,6 +64,15 @@ test("package.json exposes the sequential live verification script and side-effe
   assert.ok(packageJson.exports?.["./nta-api"]);
   assert.ok(packageJson.exports?.["./xml"]);
   assert.ok(packageJson.exports?.["./types"]);
+});
+
+test("CI workflow uses the Node 24-compatible GitHub Actions releases", () => {
+  const ciWorkflow = readFileSync(CI_WORKFLOW_PATH, "utf8");
+
+  assert.ok(ciWorkflow.includes("actions/checkout@v5"));
+  assert.ok(ciWorkflow.includes("actions/setup-node@v5"));
+  assert.ok(!ciWorkflow.includes("actions/checkout@v4"));
+  assert.ok(!ciWorkflow.includes("actions/setup-node@v4"));
 });
 
 test("manual company fixture uses readable company names", () => {


### PR DESCRIPTION
## Summary

- replace the Windows README example path with a generic placeholder
- update GitHub Actions workflow steps to the Node 24-compatible action releases
- add regression coverage for both of those docs/automation details

## Changes

- changed the copyable Windows MCP config example to use `YOUR_USERNAME` and a generic repo path
- updated `actions/checkout` and `actions/setup-node` from `@v4` to `@v5`
- extended the docs test to guard against reintroducing the local `C:\Users\owner\...` path
- added a workflow assertion so the CI file stays on the newer action versions

## Verification

- [x] `npm test`
- [x] `npm run build`
- [x] `npm run check:pack`
- [x] `npm run smoke:package`

## Notes

- I also sanitized my own previously posted GitHub issue/comment examples that contained the local Windows path.
- Secrets or real credentials not included.
